### PR TITLE
Client SDK Major Version Bump Upgrade

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@astrojs/check": "^0.5.10",
         "@astrojs/react": "^3.3.1",
-        "@stytch/react": "^17.0.0",
-        "@stytch/vanilla-js": "^4.9.1",
+        "@stytch/react": "^19.1.0",
+        "@stytch/vanilla-js": "^5.3.0",
         "@tanstack/react-query": "^5.32.0",
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
@@ -1820,30 +1820,42 @@
       "integrity": "sha512-7fedsBfuILDTBmrYZNFI8B6ATTxhQAasUHllHmjvSZPnoq4bULWoTpHwmuQvZ8Aq03/tAa2IGo6RXqWtHdWaCA=="
     },
     "node_modules/@stytch/core": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@stytch/core/-/core-2.13.1.tgz",
-      "integrity": "sha512-U7R0YdhQmg7kQQyyB+bzOpoHcAZdeAYO3r3tvUmg7tfKvVbc0Zj83W6emQ/lq8c8xIJBkubUGtsvbK0qBgYhvA==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/@stytch/core/-/core-2.26.0.tgz",
+      "integrity": "sha512-qhnjIvfaMsv9QT2cFBN+4XZ1wo+EaXnSa6jxEs9AV8xhG969QNEdAv56sSgH7TQVuG/vZhHfmyoPhnhvo9lRFQ==",
       "dependencies": {
         "uuid": "8.3.2"
       }
     },
     "node_modules/@stytch/react": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@stytch/react/-/react-17.0.0.tgz",
-      "integrity": "sha512-Kz6GYKZQdeEtOT95mi+qKUG5KIE7yFMtJ2HClYIPco8rlKtFSLvDrhG1iKhOmGUfT48P01mFKH0m7OPIIpr4lA==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@stytch/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-VXxvC5OfMw4zc1P2FjyvJSLia46CFjbzyGGz8dC6+KeiRrgsRZiVuTutfe9cluLSzhFUnEHcaPfRZaFLTGx+eg==",
       "peerDependencies": {
-        "@stytch/vanilla-js": "^4.9.0",
+        "@stytch/vanilla-js": "^5.0.0",
         "react": ">= 17.0.2",
         "react-dom": ">= 17.0.2"
       }
     },
     "node_modules/@stytch/vanilla-js": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@stytch/vanilla-js/-/vanilla-js-4.9.1.tgz",
-      "integrity": "sha512-tv23gjiMH7NrcQ06Z/WXhSAPUxNKWhd4GZDFJl6bSRedoCkSbYNYjTyVXtJuleOTppVq43HnGXVmHz0ewZjwnA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@stytch/vanilla-js/-/vanilla-js-5.3.0.tgz",
+      "integrity": "sha512-zBveMT4casOllyhCFM5KWnCXuUH4Zy6VUdBBLxWeCuJ9epVEuhyI6/F/pbBA2QCOfj1z2q5kABfggJBCy6Byqw==",
       "dependencies": {
-        "@stytch/core": "2.13.1",
-        "@types/google-one-tap": "^1.2.0"
+        "@stytch/core": "2.26.0",
+        "@types/google-one-tap": "^1.2.0",
+        "type-fest": "4.15.0"
+      }
+    },
+    "node_modules/@stytch/vanilla-js/node_modules/type-fest": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
+      "integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@tanstack/eslint-plugin-query": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@astrojs/check": "^0.5.10",
     "@astrojs/react": "^3.3.1",
-    "@stytch/react": "^17.0.0",
-    "@stytch/vanilla-js": "^4.9.1",
+    "@stytch/react": "^19.1.0",
+    "@stytch/vanilla-js": "^5.3.0",
     "@tanstack/react-query": "^5.32.0",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,7 +15,7 @@
         "cors": "^2.8.5",
         "drizzle-orm": "^0.30.9",
         "express": "^4.19.2",
-        "stytch": "^10.15.1"
+        "stytch": "^11.4.2"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.10",
@@ -23,6 +23,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/node": "^20.12.7",
+        "dotenv-cli": "^7.4.2",
         "drizzle-kit": "^0.20.17",
         "prettier": "^3.2.5",
         "ts-node": "^10.9.2",
@@ -821,14 +822,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@hono/node-server": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.11.0.tgz",
@@ -1344,6 +1337,20 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -1444,6 +1451,42 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-7.4.2.tgz",
+      "integrity": "sha512-SbUj8l61zIbzyhIbg0FwPJq6+wjbzdn9oEtozQpZ6kW2ihCcapKVZj49oCT3oPM+mgQm+itgvUQcG5szxVrZTA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "dotenv": "^16.3.0",
+        "dotenv-expand": "^10.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dreamopt": {
@@ -2171,10 +2214,16 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
     "node_modules/jose": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
-      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.8.0.tgz",
+      "integrity": "sha512-E7CqYpL/t7MMnfGnK/eg416OsFCVUrU/Y3Vwe7QjKhu/BkS1Ms455+2xsqZQVN57/U2MHMBvEb5SrmAZWAIntA==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2410,6 +2459,15 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2651,6 +2709,27 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
@@ -2761,12 +2840,12 @@
       }
     },
     "node_modules/stytch": {
-      "version": "10.15.1",
-      "resolved": "https://registry.npmjs.org/stytch/-/stytch-10.15.1.tgz",
-      "integrity": "sha512-KVOsffp2SURNEw5UwQzUx/mFKFmPpdxgwwHbgidpEDvnJXog8Uz1DuQpnwxEa6B4OMm+GW2qSTiM0zGwi8tE2Q==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/stytch/-/stytch-11.4.2.tgz",
+      "integrity": "sha512-3Q+1JE96XVMAJ6+zRCdze0NsOXEPLrXPS2Pff5ZKw4T/Q8V5a1kHzVDPNymRoPjTl2b8uSWm0CxShxCcVg3Ddw==",
       "dependencies": {
-        "jose": "^4.14.6",
-        "undici": "^5.25.4"
+        "jose": "^5.6.3",
+        "undici": "^6.19.5"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -2914,14 +2993,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -2963,6 +3039,21 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/wordwrap": {

--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
     "db:push": "drizzle-kit push:sqlite",
     "db:studio": "drizzle-kit studio",
     "build": "npx tsc",
-    "dev": "node --env-file=.env --watch --loader ts-node/esm src/index.ts",
+    "dev": "dotenv -e .env -- node --watch --loader ts-node/esm src/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "license": "MIT",
@@ -22,7 +22,7 @@
     "cors": "^2.8.5",
     "drizzle-orm": "^0.30.9",
     "express": "^4.19.2",
-    "stytch": "^10.15.1"
+    "stytch": "^11.4.2"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.10",
@@ -30,6 +30,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^20.12.7",
+    "dotenv-cli": "^7.4.2",
     "drizzle-kit": "^0.20.17",
     "prettier": "^3.2.5",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
# Description
Upgrading vanilla-js and react SDKs to account for recent version bump that introduced the following:

> Updated API routes to use api.stytch.com for live and test.stytch.com for test, replacing web.stytch.com. If you use Content Security Policy (CSP) headers, ensure the URL is updated. This was done to reduce the number of network calls and simplify internal routing, resulting in faster API response times—improving request speeds by up to 40 milliseconds roundtrip.

Also updated the dotenv cli command for loading the `.env` file, since I was running into errors with the current version.